### PR TITLE
CAV-411: Generate and Store API Key

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -99,4 +99,15 @@ microservice {
       enabled = false
     }
   }
+
+  services {
+    govuk-notify {
+      api-key {
+        iss-uuid = add5f813-2bbc-4855-a88b-3214ed8ad7bb
+        secret-key-uuid = 805c68c6-c04c-4158-95af-95f2d60238ef
+      }
+      template_id = "cd323622-57ea-4f3e-b5e0-4497452d13f3"
+      host = "http://localhost:6199"
+    }
+  }
 }


### PR DESCRIPTION
 - added default config for govuk-notify service