### PR TITLE
CAV-573: Internal Auth for cip-email-validation service

### DIFF
--- a/app/uk/gov/hmrc/cipemailverification/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/cipemailverification/config/AppConfig.scala
@@ -16,8 +16,9 @@
 
 package uk.gov.hmrc.cipemailverification.config
 
-import javax.inject.{Inject, Singleton}
 import play.api.Configuration
+
+import javax.inject.{Inject, Singleton}
 
 @Singleton
 class AppConfig @Inject()(config: Configuration) {
@@ -27,4 +28,3 @@ class AppConfig @Inject()(config: Configuration) {
   lazy val govNotifyConfig: GovNotifyConfig = config.get[GovNotifyConfig]("microservice.services.govuk-notify")
   lazy val passcodeExpiry: Long = config.get[Long]("passcode.expiry")
 }
-

--- a/app/uk/gov/hmrc/cipemailverification/config/CipValidationConfig.scala
+++ b/app/uk/gov/hmrc/cipemailverification/config/CipValidationConfig.scala
@@ -22,23 +22,24 @@ case class CipValidationConfig(
                                 protocol: String,
                                 host: String,
                                 port: Int,
+                                authToken: String,
                                 cbConfig: CircuitBreakerConfig
                               ) {
-  lazy val url: String =  s"$protocol://$host:$port"
+  lazy val url: String = s"$protocol://$host:$port"
 }
 
 object CipValidationConfig {
   implicit lazy val configLoader: ConfigLoader[CipValidationConfig] =
     ConfigLoader {
-      rootConfig => path =>
-        val config = Configuration(rootConfig.getConfig(path))
-        CipValidationConfig(
-          config.get[String]("protocol"),
-          config.get[String]("host"),
-          config.get[Int]("port"),
-          config.get[CircuitBreakerConfig]("circuit-breaker")
-        )
+      rootConfig =>
+        path =>
+          val config = Configuration(rootConfig.getConfig(path))
+          CipValidationConfig(
+            config.get[String]("protocol"),
+            config.get[String]("host"),
+            config.get[Int]("port"),
+            config.get[String]("auth-token"),
+            config.get[CircuitBreakerConfig]("circuit-breaker")
+          )
     }
 }
-
-

--- a/app/uk/gov/hmrc/cipemailverification/config/CircuitBreakerConfig.scala
+++ b/app/uk/gov/hmrc/cipemailverification/config/CircuitBreakerConfig.scala
@@ -23,17 +23,18 @@ import scala.concurrent.duration.FiniteDuration
 object CircuitBreakerConfig {
 
   implicit lazy val configLoader: ConfigLoader[CircuitBreakerConfig] = ConfigLoader {
-    rootConfig => rootPath =>
-      val config = Configuration(rootConfig.getConfig(rootPath))
-      CircuitBreakerConfig(
-        config.get[String]("service-name"),
-        config.get[Int]("max-failures"),
-        config.get[FiniteDuration]("call-timeout"),
-        config.get[FiniteDuration]("reset-timeout"),
-        config.get[FiniteDuration]("max-reset-timeout"),
-        config.get[Double]("exponential-backoff-factor"),
-        config.get[Double]("random-factor")
-      )
+    rootConfig =>
+      rootPath =>
+        val config = Configuration(rootConfig.getConfig(rootPath))
+        CircuitBreakerConfig(
+          config.get[String]("service-name"),
+          config.get[Int]("max-failures"),
+          config.get[FiniteDuration]("call-timeout"),
+          config.get[FiniteDuration]("reset-timeout"),
+          config.get[FiniteDuration]("max-reset-timeout"),
+          config.get[Double]("exponential-backoff-factor"),
+          config.get[Double]("random-factor")
+        )
   }
 }
 
@@ -45,4 +46,3 @@ case class CircuitBreakerConfig(
                                  maxResetTimeout: FiniteDuration,
                                  exponentialBackoffFactor: Double,
                                  randomFactor: Double)
-

--- a/app/uk/gov/hmrc/cipemailverification/config/GovNotifyConfig.scala
+++ b/app/uk/gov/hmrc/cipemailverification/config/GovNotifyConfig.scala
@@ -29,16 +29,15 @@ case class GovNotifyConfig(
 object GovNotifyConfig {
   implicit lazy val configLoader: ConfigLoader[GovNotifyConfig] =
     ConfigLoader {
-      rootConfig => path =>
-        val config = Configuration(rootConfig.getConfig(path))
-        GovNotifyConfig(
-          config.get[String]("host"),
-          config.get[String]("template_id"),
-          config.get[String]("api-key.iss-uuid"),
-          config.get[String]("api-key.secret-key-uuid"),
-          config.get[CircuitBreakerConfig]("circuit-breaker")
-        )
+      rootConfig =>
+        path =>
+          val config = Configuration(rootConfig.getConfig(path))
+          GovNotifyConfig(
+            config.get[String]("host"),
+            config.get[String]("template_id"),
+            config.get[String]("api-key.iss-uuid"),
+            config.get[String]("api-key.secret-key-uuid"),
+            config.get[CircuitBreakerConfig]("circuit-breaker")
+          )
     }
 }
-
-

--- a/app/uk/gov/hmrc/cipemailverification/config/Module.scala
+++ b/app/uk/gov/hmrc/cipemailverification/config/Module.scala
@@ -25,4 +25,3 @@ class Module extends AbstractModule {
     bind(classOf[AppConfig]).asEagerSingleton()
   }
 }
-

--- a/app/uk/gov/hmrc/cipemailverification/connectors/CircuitBreakerWrapper.scala
+++ b/app/uk/gov/hmrc/cipemailverification/connectors/CircuitBreakerWrapper.scala
@@ -27,6 +27,7 @@ import scala.util.Try
 
 trait CircuitBreakerWrapper extends Logging {
   protected def materializer: Materializer
+
   def configCB: CircuitBreakerConfig
 
   def withCircuitBreaker[T](block: => Future[T])(implicit connectionFailure: Try[T] => Boolean): Future[T] =
@@ -52,4 +53,3 @@ trait CircuitBreakerWrapper extends Logging {
         logger.warn(s"Circuit breaker for ${configCB.serviceName} recorded failed call due to timeout after ${duration.toMillis}ms")
     }
 }
-

--- a/app/uk/gov/hmrc/cipemailverification/connectors/ValidatorConnector.scala
+++ b/app/uk/gov/hmrc/cipemailverification/connectors/ValidatorConnector.scala
@@ -20,16 +20,17 @@ import akka.stream.Materializer
 import play.api.Logging
 import play.api.libs.json.Json
 import uk.gov.hmrc.cipemailverification.config.{AppConfig, CircuitBreakerConfig}
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
-import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 @Singleton
-class ValidateConnector @Inject()(httpClientV2: HttpClientV2, config: AppConfig)(implicit ec: ExecutionContext, val materializer: Materializer)
+class ValidateConnector @Inject()(httpClientV2: HttpClientV2, config: AppConfig)
+                                 (implicit ec: ExecutionContext, val materializer: Materializer)
   extends Logging with CircuitBreakerWrapper {
 
   implicit val connectionFailure: Try[HttpResponse] => Boolean = {
@@ -42,10 +43,10 @@ class ValidateConnector @Inject()(httpClientV2: HttpClientV2, config: AppConfig)
       httpClientV2
         .post(url"${config.validationConfig.url}/customer-insight-platform/email/validate")
         .withBody(Json.obj("email" -> s"$email"))
+        .setHeader(("Authorization", config.validationConfig.authToken))
         .execute[HttpResponse]
     )
   }
 
   override def configCB: CircuitBreakerConfig = config.validationConfig.cbConfig
 }
-

--- a/app/uk/gov/hmrc/cipemailverification/models/EmailPasscodeData.scala
+++ b/app/uk/gov/hmrc/cipemailverification/models/EmailPasscodeData.scala
@@ -16,11 +16,10 @@
 
 package uk.gov.hmrc.cipemailverification.models
 
-import play.api.libs.json.{Json, Reads, Writes}
+import play.api.libs.json.Json
 
 case class EmailPasscodeData(email: String, passcode: String, createdAt: Long)
 
 object EmailPasscodeData {
   implicit val emailPasscodeDataFormat = Json.format[EmailPasscodeData]
 }
-

--- a/app/uk/gov/hmrc/cipemailverification/models/api/Email.scala
+++ b/app/uk/gov/hmrc/cipemailverification/models/api/Email.scala
@@ -21,6 +21,5 @@ import play.api.libs.json.Json
 case class Email(email: String)
 
 object Email {
-   implicit val emailReads = Json.reads[Email]
+  implicit val emailReads = Json.reads[Email]
 }
-

--- a/app/uk/gov/hmrc/cipemailverification/models/http/govnotify/GovUkNotificationId.scala
+++ b/app/uk/gov/hmrc/cipemailverification/models/http/govnotify/GovUkNotificationId.scala
@@ -23,4 +23,3 @@ case class GovUkNotificationId(id: String)
 object GovUkNotificationId {
   implicit val reads: Reads[GovUkNotificationId] = Json.reads[GovUkNotificationId]
 }
-

--- a/app/uk/gov/hmrc/cipemailverification/repositories/PasscodeCacheRepository.scala
+++ b/app/uk/gov/hmrc/cipemailverification/repositories/PasscodeCacheRepository.scala
@@ -17,8 +17,8 @@
 package uk.gov.hmrc.cipemailverification.repositories
 
 import uk.gov.hmrc.cipemailverification.config.AppConfig
-import uk.gov.hmrc.mongo.{MongoComponent, TimestampSupport}
 import uk.gov.hmrc.mongo.cache.{CacheIdType, MongoCacheRepository}
+import uk.gov.hmrc.mongo.{MongoComponent, TimestampSupport}
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
@@ -31,4 +31,3 @@ class PasscodeCacheRepository @Inject()(mongoComponent: MongoComponent, config: 
     ttl = config.cacheExpiry.minutes,
     timestampSupport = timestampSupport,
     cacheIdType = CacheIdType.SimpleCacheId)
-

--- a/app/uk/gov/hmrc/cipemailverification/services/PasscodeGenerator.scala
+++ b/app/uk/gov/hmrc/cipemailverification/services/PasscodeGenerator.scala
@@ -33,4 +33,3 @@ class PasscodeGenerator {
     sb.mkString
   }
 }
-

--- a/app/uk/gov/hmrc/cipemailverification/services/PasscodeService.scala
+++ b/app/uk/gov/hmrc/cipemailverification/services/PasscodeService.scala
@@ -37,5 +37,3 @@ class PasscodeService @Inject()(passcodeCacheRepository: PasscodeCacheRepository
     passcodeCacheRepository.get[EmailPasscodeData](email)(DataKey("cip-email-verification"))
   }
 }
-
-

--- a/app/uk/gov/hmrc/cipemailverification/services/VerifyService.scala
+++ b/app/uk/gov/hmrc/cipemailverification/services/VerifyService.scala
@@ -32,12 +32,12 @@ import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
-class VerifyService @Inject() (passcodeGenerator: PasscodeGenerator,
-                               passcodeService: PasscodeService,
-                               dateTimeUtils: DateTimeUtils,
-                               govUkConnector: GovUkConnector,
-                               validateConnector: ValidateConnector,
-                               config: AppConfig)(implicit val executionContext: ExecutionContext) extends
+class VerifyService @Inject()(passcodeGenerator: PasscodeGenerator,
+                              passcodeService: PasscodeService,
+                              dateTimeUtils: DateTimeUtils,
+                              govUkConnector: GovUkConnector,
+                              validateConnector: ValidateConnector,
+                              config: AppConfig)(implicit val executionContext: ExecutionContext) extends
   VerifyHelper(passcodeGenerator, passcodeService, govUkConnector, dateTimeUtils, config) {
 
   def verifyEmail(email: Email)(implicit hc: HeaderCarrier): Future[Result] =
@@ -57,4 +57,3 @@ class VerifyService @Inject() (passcodeGenerator: PasscodeGenerator,
     }
   }
 }
-

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -131,6 +131,7 @@ microservice {
         protocol = http
         host = localhost
         port = 6182
+        auth-token = fake-token
         circuit-breaker {
           service-name = "Validation service"
           max-failures  = 2

--- a/it/uk/gov/hmrc/cipemailverification/HealthEndpointIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/cipemailverification/HealthEndpointIntegrationSpec.scala
@@ -20,24 +20,16 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws.WSClient
 
-class HealthEndpointIntegrationSpec
-  extends AnyWordSpec
-     with Matchers
-     with ScalaFutures
-     with IntegrationPatience
-     with GuiceOneServerPerSuite {
+class HealthEndpointIntegrationSpec extends AnyWordSpec
+  with Matchers
+  with ScalaFutures
+  with IntegrationPatience
+  with GuiceOneServerPerSuite {
 
   private val wsClient = app.injector.instanceOf[WSClient]
-  private val baseUrl  = s"http://localhost:$port"
-
-  override def fakeApplication(): Application =
-    GuiceApplicationBuilder()
-      .configure("metrics.enabled" -> false)
-      .build()
+  private val baseUrl = s"http://localhost:$port"
 
   "service health endpoint" should {
     "respond with 200 status" in {

--- a/test/uk/gov/hmrc/cipemailverification/connectors/CircuitBreakerWrapperSpec.scala
+++ b/test/uk/gov/hmrc/cipemailverification/connectors/CircuitBreakerWrapperSpec.scala
@@ -23,14 +23,13 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.http.Status.OK
 import play.api.libs.json.Json
-import play.api.test.Helpers.await
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.cipemailverification.TestActorSystem
 import uk.gov.hmrc.cipemailverification.config.CircuitBreakerConfig
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
-import play.api.test.Helpers.{await, defaultAwaitTimeout}
-import scala.concurrent.ExecutionContext.Implicits.global
 import uk.gov.hmrc.http.test.{HttpClientV2Support, WireMockSupport}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
 import scala.util.{Failure, Success, Try}
 

--- a/test/uk/gov/hmrc/cipemailverification/connectors/GovUkConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cipemailverification/connectors/GovUkConnectorSpec.scala
@@ -17,8 +17,7 @@
 package uk.gov.hmrc.cipemailverification.connectors
 
 import com.github.tomakehurst.wiremock.client.WireMock._
-import org.mockito.Mockito.when
-import org.mockito.MockitoSugar.mock
+import org.mockito.IdiomaticMockito
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -39,7 +38,8 @@ class GovUkConnectorSpec extends AnyWordSpec
   with WireMockSupport
   with ScalaFutures
   with HttpClientV2Support
-  with TestActorSystem {
+  with TestActorSystem
+  with IdiomaticMockito {
 
   val notificationId = "test-notification-id"
   val emailUrl: String = "/v2/notifications/email"
@@ -52,10 +52,10 @@ class GovUkConnectorSpec extends AnyWordSpec
           .willReturn(aResponse())
       )
 
-      when(appConfigMock.govNotifyConfig).thenReturn(GovNotifyConfig(
+      appConfigMock.govNotifyConfig.returns(GovNotifyConfig(
         wireMockUrl, "template-id-fake", "", UUID.randomUUID().toString, cbConfigData))
 
-      when(appConfigMock.cacheExpiry).thenReturn(1)
+      appConfigMock.cacheExpiry.returns(1)
 
       val result = govUkConnector.notificationStatus(notificationId)
       await(result).right.get.status shouldBe OK
@@ -73,10 +73,10 @@ class GovUkConnectorSpec extends AnyWordSpec
           .willReturn(aResponse())
       )
 
-      when(appConfigMock.govNotifyConfig).thenReturn(GovNotifyConfig(
+      appConfigMock.govNotifyConfig.returns(GovNotifyConfig(
         wireMockUrl, "template-id-fake", "", UUID.randomUUID().toString, cbConfigData))
 
-      when(appConfigMock.passcodeExpiry).thenReturn(15)
+      appConfigMock.passcodeExpiry.returns(15)
 
       val now = System.currentTimeMillis()
       val emailPasscodeData = EmailPasscodeData("test@test.com", "testPasscode", now)
@@ -105,13 +105,14 @@ class GovUkConnectorSpec extends AnyWordSpec
     protected implicit val hc: HeaderCarrier = HeaderCarrier()
     protected val appConfigMock = mock[AppConfig]
     val cbConfigData = CircuitBreakerConfig("", 5, 5.toDuration, 30.toDuration, 5.toDuration, 1, 0)
+
     implicit class IntToDuration(timeout: Int) {
       def toDuration = Duration(timeout, java.util.concurrent.TimeUnit.SECONDS)
     }
+
     val govUkConnector = new GovUkConnector(
       httpClientV2,
       appConfigMock
     )
   }
-
 }

--- a/test/uk/gov/hmrc/cipemailverification/services/PasscodeGeneratorSpec.scala
+++ b/test/uk/gov/hmrc/cipemailverification/services/PasscodeGeneratorSpec.scala
@@ -20,7 +20,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class PasscodeGeneratorSpec extends AnyWordSpec
-  with Matchers{
+  with Matchers {
 
   private val passcodeGenerator = new PasscodeGenerator()
 

--- a/test/uk/gov/hmrc/cipemailverification/services/VerifyServiceSpec.scala
+++ b/test/uk/gov/hmrc/cipemailverification/services/VerifyServiceSpec.scala
@@ -293,5 +293,3 @@ class VerifyServiceSpec extends AnyWordSpec
       appConfig)
   }
 }
-
-


### PR DESCRIPTION
 - add auth token to Authorization header when calling validation service
 - minor refactoring and tidy-up